### PR TITLE
feat: Inject Entity\Claims::$config from args of Authorize::__construct

### DIFF
--- a/src/Authorize.php
+++ b/src/Authorize.php
@@ -34,6 +34,7 @@ class Authorize {
     protected $jwt;
     protected $jwks = [];
     protected $customDomain;
+    protected $claims_config = [];
 
     public function __construct(Client $client, JWT $jwt, array $config)
     {
@@ -44,6 +45,7 @@ class Authorize {
         $this->client_secret = $config['client_secret'] ?? '';
         $this->flow = $config['flow'] ?? null;
         $this->customDomain = $config['custom_domain'] ?? null;
+        $this->claims_config = $config['claims_config'] ?? null;
 
         if (array_key_exists('jwks', $config) && is_array($config['jwks'])) {
             $this->jwks = $config['jwks'];
@@ -177,7 +179,8 @@ class Authorize {
         $accessToken = new AccessToken(json_decode((string)$response->getBody()->getContents(), true));
 
         $claims = $this->verifyToken($accessToken->accessToken, $flow);
-        $accessToken->setClaims($claims);
+
+        $accessToken->setClaims($claims, $this->claims_config);
 
         return $accessToken;
     }

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -36,9 +36,9 @@ class AccessToken extends BaseEntity {
 
     protected $claims;
 
-    public function setClaims(array $claims): void
+    public function setClaims(array $claims, array $config = null): void
     {
-        $this->claims = new Claims($claims);
+        $this->claims = new Claims($claims, $config);
     }
 
     public function getClaims(): Claims

--- a/src/Entity/Claims.php
+++ b/src/Entity/Claims.php
@@ -57,6 +57,14 @@ class Claims extends BaseEntity {
         ],
     ];
 
+    public function __construct(array $data, array $config = null)
+    {
+        if ($config !== null) {
+            $this->config = $config;
+        }
+        parent::__construct($data);
+    }
+
     public function getFullName(string $locale): string
     {
         $fullName = '';


### PR DESCRIPTION
- what
  - `Entity\Claims::$config` を `Authorize::__construct` の引数の `$config` で渡せるように改修
- why
  - ユーザーフロー と カスタムポリシー で id token の claims が異なる
    - カスタムポリシーの claims に対応した Claims Entity を生成したい